### PR TITLE
👽 fix deprecated fakerjs function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pusakatest",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "pusakatest is an automation testing tool based on pactum using bdd (cucumber) style",
   "main": "index.js",
   "bin": "bin/create-project",

--- a/templates/english/features/support/data.js
+++ b/templates/english/features/support/data.js
@@ -1,7 +1,7 @@
 const { faker } = require('@faker-js/faker')
 
 const randomData = {
-    name: faker.name.fullName(),
+    name: faker.person.fullName(),
     email: faker.internet.email(),
     password: faker.internet.password()
 }

--- a/templates/english/package.json
+++ b/templates/english/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pusakatest",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "pusakatest is an automation testing tool based on pactum using bdd (cucumber) style",
     "main": "index.js",
     "scripts": {

--- a/templates/hindi/features/support/data.js
+++ b/templates/hindi/features/support/data.js
@@ -1,7 +1,7 @@
 const { faker } = require('@faker-js/faker')
 
 const randomData = {
-    name: faker.name.fullName(),
+    name: faker.person.fullName(),
     email: faker.internet.email(),
     password: faker.internet.password()
 }

--- a/templates/hindi/package.json
+++ b/templates/hindi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pusakatest",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "pusakatest is an automation testing tool based on pactum using bdd (cucumber) style",
     "main": "index.js",
     "scripts": {

--- a/templates/indonesian/features/support/data.js
+++ b/templates/indonesian/features/support/data.js
@@ -1,7 +1,7 @@
 const { faker } = require('@faker-js/faker')
 
 const randomData = {
-    name: faker.name.fullName(),
+    name: faker.person.fullName(),
     email: faker.internet.email(),
     password: faker.internet.password()
 }

--- a/templates/indonesian/package.json
+++ b/templates/indonesian/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pusakatest",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "pusakatest is an automation testing tool based on pactum using bdd (cucumber) style",
     "main": "index.js",
     "scripts": {

--- a/templates/korean/package.json
+++ b/templates/korean/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pusakatest",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "pusakatest is an automation testing tool based on pactum using bdd (cucumber) style",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
```
[@faker-js/faker]: faker.name is deprecated since v8.0 and will be removed in v10.0. Please use faker.person instead.
```